### PR TITLE
Add BEV grid tokens for trajectory prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,23 @@ Stage 3 Script:
 
 ## Finetune from LLaDA-V
 ```bash
-Script: 
+Script:
    cd train && bash scripts/llada_v_finetune.sh
    note: you need to add the path of "data_path", "image_folder", "video_folder" in llada_v_finetune.sh.
 ```
+
+## BEV Trajectory Tokens
+
+To enable vehicle trajectory prediction with grid classification, you can
+activate the new token set representing BEV coordinates. When launching
+`train/train.py`, pass `--add_bev_tokens` to expand the vocabulary with 13,200
+special tokens in the form `<bev_{x}_{y}>`. The BEV grid covers:
+
+- **X axis**: five ranges `[-40,-20,2]`, `[-20,0,1]`, `[0,20,0.5]`, `[20,40,1]`, `[40,80,2]`.
+- **Y axis**: single range `[-60,60,1]`.
+
+These tokens can be used to represent 8 successive trajectory points by outputting
+a sequence of grid tokens.
 
 
 ## Evaluation

--- a/train/llava/bev_utils.py
+++ b/train/llava/bev_utils.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+# Generate grid coordinates based on given ranges
+X_GRID_RANGES = [
+    (-40, -20, 2),
+    (-20, 0, 1),
+    (0, 20, 0.5),
+    (20, 40, 1),
+    (40, 80, 2),
+]
+Y_GRID_RANGE = (-60, 60, 1)
+
+# Pre-compute bin centers for x and y
+x_bins = []
+for start, end, step in X_GRID_RANGES:
+    x_bins.extend(np.arange(start, end, step).tolist())
+# ensure inclusive of end?
+x_bins = np.array(x_bins)
+y_bins = np.arange(Y_GRID_RANGE[0], Y_GRID_RANGE[1], Y_GRID_RANGE[2])
+
+def bev_tokens():
+    """Return list of token strings for all grid positions."""
+    tokens = []
+    for xi in range(len(x_bins)):
+        for yi in range(len(y_bins)):
+            tokens.append(f"<bev_{xi}_{yi}>")
+    return tokens
+
+def clamp_index(value, bins):
+    """Clip value to range and return nearest index."""
+    idx = np.argmin(np.abs(bins - value))
+    return int(idx)
+
+def coord_to_token(x, y):
+    """Convert real world coordinate to token."""
+    xi = clamp_index(x, x_bins)
+    yi = clamp_index(y, y_bins)
+    return f"<bev_{xi}_{yi}>"

--- a/train/llava/train/train.py
+++ b/train/llava/train/train.py
@@ -44,6 +44,7 @@ import deepspeed
 from transformers import AutoConfig
 from torch.utils.data import Dataset
 from llava.constants import IGNORE_INDEX, DEFAULT_IMAGE_TOKEN, DEFAULT_IM_START_TOKEN, DEFAULT_IM_END_TOKEN, IMAGE_TOKEN_INDEX
+from llava.bev_utils import bev_tokens
 from llava.train.llava_trainer import LLaVATrainer
 
 from llava import conversation as conversation_lib
@@ -141,6 +142,7 @@ class DataArguments:
     frames_upbound: Optional[int] = field(default=0)
     add_time_instruction: Optional[bool] = field(default=False)
     force_sample: Optional[bool] = field(default=False)
+    add_bev_tokens: Optional[bool] = field(default=False, metadata={"help": "Add BEV action tokens for trajectory classification"})
 
 
 @dataclass
@@ -1877,6 +1879,12 @@ def train(attn_implementation=None):
                 tokenizer=tokenizer,
                 model=model,
             )
+    if data_args.add_bev_tokens:
+        smart_tokenizer_and_embedding_resize(
+            special_tokens_dict={"additional_special_tokens": bev_tokens()},
+            tokenizer=tokenizer,
+            model=model,
+        )
     elif model_args.version == "v0.5":
         tokenizer.pad_token = tokenizer.unk_token
     else:


### PR DESCRIPTION
## Summary
- introduce `bev_utils` helper for BEV grid tokenization
- support optional `--add_bev_tokens` in training script
- document BEV trajectory tokens in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847b2981da88333bf08b06bad649bec